### PR TITLE
Remove tier dates - auto-approve stats

### DIFF
--- a/CovidStateDashboard/datasetUpdates/index.js
+++ b/CovidStateDashboard/datasetUpdates/index.js
@@ -12,7 +12,6 @@ const {
 } = require('../../common/gitHub');
 
 const PrLabels = ['Automatic Deployment'];
-const tierUpdateDay = 1 //Monday
 
 //Check to see if we need stats update PRs, make them if we do.
 const doDailyStatsPr = async mergetargets => {
@@ -32,29 +31,15 @@ const doDailyStatsPr = async mergetargets => {
 
         sqlResults = sqlResults || (await queryDataset(sql))[0][0]; //only run the query if needed
 
-        //Add tier dates
-        let target = new Date();
-        while(target.getDay()!==tierUpdateDay)
-            target.setDate(target.getDate() - 1);
-        sqlResults[0].TIER_DATE = target.toJSON().split('T')[0];
-
-
-        target.setDate(target.getDate() - 7); //Go back a week
-        while(target.getDay()!==6) //Look back for a Saturday
-            target.setDate(target.getDate() - 1);
-
-        sqlResults[0].TIER_ENDDATE = target.toJSON().split('T')[0];
-
         const content = Buffer.from(JSON.stringify(sqlResults,null,2)).toString('base64');
 
         await gitHubBranchCreate(branch,mergetarget);
         const targetfile = await gitHubFileGet(`pages/_data/${statsFileName}`,branch);
         await gitHubFileUpdate(content,targetfile.url,targetfile.sha,gitHubMessage(`${today} Update`,statsFileName),branch);
-        const autoApproveMerge = !isMaster || (new Date()).getDay()!==tierUpdateDay; //Don't auto-merge on tierUpdateDay
+        const autoApproveMerge = true; //Always approve daily stats
         const PrTitle = `${today} Stats Update${(isMaster) ? `` : ` (${mergetarget})`}`;
         const Pr = 
-            await gitHubBranchMerge(branch,mergetarget,true,PrTitle,PrLabels,false);
-        // await gitHubBranchMerge(branch,mergetarget,true,PrTitle,PrLabels,autoApproveMerge);
+            await gitHubBranchMerge(branch,mergetarget,true,PrTitle,PrLabels,autoApproveMerge);
         if(isMaster) {
             masterPr = Pr;
         }


### PR DESCRIPTION
Now that the tiers are set in Wordpress, we can safely update the daily stats again.