### PR TITLE
fixing slackbot notification (preventing error)

### DIFF
--- a/CovidWeeklyTierUpdateHttpTrigger/index.js
+++ b/CovidWeeklyTierUpdateHttpTrigger/index.js
@@ -14,7 +14,7 @@ module.exports = async function (context, req) {
 
         activity.report = await doWeeklyUpdatePrs(mergetargets);
 
-        for (const val of report) {
+        for (const val of activity.report) {
             await slackBotChatPost(notifyChannel,`Tier Update Deployed\n${val.Pr.html_url}`);
         }
 


### PR DESCRIPTION
Cron job is not completing because the slack reporting is using the old object.