### PR TITLE
Package name fix

### DIFF
--- a/covidE2E/package.json
+++ b/covidE2E/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "covidE2E",
+  "name": "covid-e2e",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cagov/Cron",
+  "name": "cagov-cron",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
The package names were not passing the regex validation.

`String does not match the pattern of "^(?:@[a-z0-9-*~][a-z0-9-*._~]*/)?[a-z0-9-~][a-z0-9-._~]*$".`