### PR TITLE
Properly controlling error message flow for SQL errors

### DIFF
--- a/common/snowflakeQuery/index.js
+++ b/common/snowflakeQuery/index.js
@@ -1,4 +1,5 @@
 const snowflake = require('snowflake-sdk');
+//https://docs.snowflake.com/en/user-guide/nodejs-driver.html
 
 const queryDataset = async (sql, connection) => {
     connection = connection || getDatabaseConnection();
@@ -9,9 +10,9 @@ const queryDataset = async (sql, connection) => {
             sqlText : sql,
             complete: function(err, stmt, rows) {
                 if (err) {
-                    throw new Error(err.message);
+                    reject(err);
                 } else {
-                    console.log('Successfully executed statement: ' + stmt.getSqlText());
+                    console.log(`Successfully executed statement: ${stmt.getSqlText()}`);
                     resolve(rows);
                 }
             }
@@ -26,7 +27,7 @@ const queryDataset = async (sql, connection) => {
         });
 
     return result;
-}
+};
 
 const getDatabaseConnection = () => {
     const attrs = {
@@ -34,7 +35,7 @@ const getDatabaseConnection = () => {
         username: process.env["SNOWFLAKE_USER"],
         password: process.env["SNOWFLAKE_PASS"],
         warehouse: 'COVID_CDPH_VWH'
-    }
+    };
 
     if (!attrs.username || !attrs.password) {
         //developers that don't set the creds can still use the rest of the code
@@ -44,19 +45,19 @@ const getDatabaseConnection = () => {
 
     const connection = snowflake.createConnection(attrs);
 
-	// Try to connect to Snowflake, and check whether the connection was successful.
-	connection.connect(function(err, conn) {
-		if (err) {
-            throw new Error('Unable to connect: ' + err.message);
-		} else {
+    // Try to connect to Snowflake, and check whether the connection was successful.
+    connection.connect(err => {
+        if (err) {
+            console.error(err);
+        } else {
             console.log('Successfully connected to Snowflake.');
-		}
+        }
     });
 
     return connection;
-}
+};
 
 module.exports = {
     getDatabaseConnection,
     queryDataset
-}
+};

--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -85,4 +85,7 @@ const doWork = async opt => {
             process.exit(0);
         });
     }
-})();
+})()
+.catch(e=>{
+    console.error(e);
+});


### PR DESCRIPTION
Snowflake SQL errors are not properly bubbling to the top level catch.  This should fix it.