### PR TITLE
Turned off automatic running of state dash crons until March. 

### DIFF
--- a/CovidStateDashboard/function.json
+++ b/CovidStateDashboard/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboard",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 45 18 * * *"
+      "schedule": "0 45 18 * March *"
     }
   ]
 }

--- a/CovidStateDashboardV2/function.json
+++ b/CovidStateDashboardV2/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardV2",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0/30 18-21 * * *"
+      "schedule": "0 0/30 18-21 * March *"
     }
   ]
 }


### PR DESCRIPTION
A temporary stoppage so we can deploy state-dash later in the day.  These will be turned back on in a day or two.  In the meantime, Crons should be run locally when data refreshes are needed.
