### PR TITLE
Vaccine Equity Data Race/Ethnicity category fix

### DIFF
--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -133,9 +133,6 @@ const doCovidVaccineEquity = async () => {
             FROM: "Other Race"
         },
         {
-            CATEGORY: "Unable to report due to policy/law"
-        },
-        {
             CATEGORY: "Unknown"
         }
     ];

--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -72,7 +72,13 @@ const doCovidVaccineEquity = async () => {
                     data.sort(sortFunction);
 
                     data.forEach(x=>{
-                        x.CATEGORY = sortMap[sortMapA.indexOf(x.CATEGORY)].CATEGORY;
+                        const replacementIndex = sortMapA.indexOf(x.CATEGORY);
+
+                        if (replacementIndex===-1) {
+                            console.error(`missing sortmap CATEGORY - "${x.CATEGORY}".\nFile - ${path_prefix}`);
+                        } else {
+                            x.CATEGORY = sortMap[replacementIndex].CATEGORY;
+                        }
                     });
                 }
 
@@ -121,6 +127,9 @@ const doCovidVaccineEquity = async () => {
         {
             CATEGORY: "Other",
             FROM: "Other Race"
+        },
+        {
+            CATEGORY: "Unable to report due to policy/law"
         },
         {
             CATEGORY: "Unknown"

--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -152,9 +152,6 @@ const doCovidVaccineEquity = async () => {
         },
         {
             CATEGORY: "65+"
-        },
-        {
-            CATEGORY: "Unknown"
         }
     ];
 

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_age.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_age.sql
@@ -21,7 +21,19 @@ GB as ( --Master list of corrected data grouped by region/category
     count(distinct recip_id) "ADMIN_COUNT", --For total people
     MAX(case when DATE(ADMIN_DATE)>DATE(GETDATE()) then NULL else DATE(ADMIN_DATE) end) "LATEST_ADMIN_DATE"
   from
-    CA_VACCINE.tab_int_test
+    (select 
+     *,
+        replace( 
+            iff(RECIP_ADDRESS_STATE = 'CA',
+                iff(RECIP_ADDRESS_COUNTY ='Unknown' , 
+                   iff(ADMIN_ADDRESS_COUNTY is null,
+                       'Unknown'
+                   ,ADMIN_ADDRESS_COUNTY)
+               ,RECIP_ADDRESS_COUNTY)
+            ,'Outside California')
+        ,' County') 
+       AS Mixed_county
+    from CA_VACCINE_UAT.VW_TAB_INT_ALL) foo
   left outer join
     ranges
     on RMIN<=DATEDIFF('yyyy',DATE(RECIP_DOB),GETDATE())

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_age.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_age.sql
@@ -33,7 +33,7 @@ GB as ( --Master list of corrected data grouped by region/category
             ,'Outside California')
         ,' County') 
        AS Mixed_county
-    from CA_VACCINE_UAT.VW_TAB_INT_ALL) foo
+    from CA_VACCINE.VW_TAB_INT_ALL) foo
   left outer join
     ranges
     on RMIN<=DATEDIFF('yyyy',DATE(RECIP_DOB),GETDATE())

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_gender.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_gender.sql
@@ -25,7 +25,7 @@ GB as ( --Master list of corrected data grouped by region/category
             ,'Outside California')
         ,' County') 
        AS Mixed_county
-    from CA_VACCINE_UAT.VW_TAB_INT_ALL) foo
+    from CA_VACCINE.VW_TAB_INT_ALL) foo
   where
     RECIP_ID IS NOT NULL
   group by

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_gender.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_gender.sql
@@ -13,7 +13,19 @@ GB as ( --Master list of corrected data grouped by region/category
     count(distinct recip_id) "ADMIN_COUNT", --For total people
     MAX(case when DATE(ADMIN_DATE)>DATE(GETDATE()) then NULL else DATE(ADMIN_DATE) end) "LATEST_ADMIN_DATE"
   from
-    CA_VACCINE.tab_int_test
+    (select 
+     *,
+        replace( 
+            iff(RECIP_ADDRESS_STATE = 'CA',
+                iff(RECIP_ADDRESS_COUNTY ='Unknown' , 
+                   iff(ADMIN_ADDRESS_COUNTY is null,
+                       'Unknown'
+                   ,ADMIN_ADDRESS_COUNTY)
+               ,RECIP_ADDRESS_COUNTY)
+            ,'Outside California')
+        ,' County') 
+       AS Mixed_county
+    from CA_VACCINE_UAT.VW_TAB_INT_ALL) foo
   where
     RECIP_ID IS NOT NULL
   group by

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_race_eth.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_race_eth.sql
@@ -26,7 +26,7 @@ GB as ( --Master list of corrected data grouped by region/category
             ,'Outside California')
         ,' County') 
        AS Mixed_county
-    from CA_VACCINE_UAT.VW_TAB_INT_ALL) foo
+    from CA_VACCINE.VW_TAB_INT_ALL) foo
   where
     RECIP_ID IS NOT NULL
   group by

--- a/common/SQL/CDTCDPH_VACCINE/vaccines_by_race_eth.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccines_by_race_eth.sql
@@ -5,7 +5,7 @@
 with
 GB as ( --Master list of corrected data grouped by region/category
   select
-    coalesce(RACE_ETH,'Unknown') "CATEGORY",
+    case RACE_ETH when 'Unable to report due to policy/law' then 'Unknown' else coalesce(RACE_ETH,'Unknown') end "CATEGORY",
     case when MIXED_COUNTY in
         ('Alameda','Alpine','Amador','Butte','Calaveras','Colusa','Contra Costa','Del Norte','El Dorado','Fresno','Glenn','Humboldt','Imperial','Inyo','Kern','Kings','Lake','Lassen','Los Angeles','Madera','Marin','Mariposa','Mendocino','Merced','Modoc','Mono','Monterey','Napa','Nevada','Orange','Placer','Plumas','Riverside','Sacramento','San Benito','San Bernardino','San Diego','San Francisco','San Joaquin','San Luis Obispo','San Mateo','Santa Barbara','Santa Clara','Santa Cruz','Shasta','Sierra','Siskiyou','Solano','Sonoma','Stanislaus','Sutter','Tehama','Trinity','Tulare','Tuolumne','Ventura','Yolo','Yuba')
     then MIXED_COUNTY else 'Unknown' end "REGION",

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,11 +225,11 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "bcrypt-pbkdf": {
@@ -926,27 +926,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -990,11 +972,11 @@
       }
     },
     "github-api": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.3.0.tgz",
-      "integrity": "sha512-30pABj/1ciHmlqmjnWXn+A4JL8j9qB2IcQgibrJ7euGbaNRkAj+T6QhJwjLcPx4Hxlj+BP1TcdvaQ/7resw+VA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.4.0.tgz",
+      "integrity": "sha512-2yYqYS6Uy4br1nw0D3VrlYWxtGTkUhIZrumBrcBwKdBOzMT8roAe8IvI6kjIOkxqxapKR5GkEsHtz3Du/voOpA==",
       "requires": {
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "debug": "^2.2.0",
         "js-base64": "^2.1.9",
         "utf8": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "calibre": "^3.2.0",
-    "github-api": "^3.3.0",
+    "github-api": "^3.4.0",
     "jsdom": "^16.4.0",
     "md5": "^2.3.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
Fixes an issue with unidentified categories preventing deployment.

Moves all 'Unable to report due to policy/law' to 'unknown' in the data.

No longer adds "Unknown" to age data.

Uses a new view "CA_VACCINE.VW_TAB_INT_ALL"

created...
https://github.com/cagov/covid-static/pull/211