### PR TITLE
Bug fix v2 dash branch naming

### DIFF
--- a/CovidStateDashboardV2/worker.js
+++ b/CovidStateDashboardV2/worker.js
@@ -71,8 +71,8 @@ const processFilesForPr = async (fileData, gitRepo, prTitle) => {
  * @returns {Promise<{html_url:string}>} The PR created if a change was made
  */
 const createPrForChange = async (gitRepo, Pr, path, json, prTitle) => {
-    const branchName = `auto-${prTitle.replace(/ /g,'-')}-${todayDateString()}-${todayTimeString()}`;
-    const targetcontent = (await gitRepo.getContents(Pr ? branchName : masterBranch,path,true)).data;
+    const branchName = Pr ? Pr.head.ref : `auto-${prTitle.replace(/ /g,'-')}-${todayDateString()}-${todayTimeString()}`;
+    const targetcontent = (await gitRepo.getContents(Pr ? Pr.head.ref : masterBranch,path,true)).data;
 
     //Add publishedDate
     if(!json.meta) {

--- a/CovidStateDashboardV2/worker.js
+++ b/CovidStateDashboardV2/worker.js
@@ -64,7 +64,7 @@ const processFilesForPr = async (fileData, gitRepo, prTitle) => {
 /**
  * If changes are detected, create and return a PR, or reuse a PR
  * @param {*} gitRepo 
- * @param {{}} [Pr] The PR from previous runs
+ * @param {{head:{ref:string}}} [Pr] The PR from previous runs
  * @param {string} path path of the file to update
  * @param {{data:{}}} json data to send
  * @param {string} prTitle title for PR if created


### PR DESCRIPTION
Branch name of created PR was not being retained, causing 404 errors because the seconds on the new branch name would change.

Fixes...
Error: 404 error making request get https://api.github.com/repos/cagov/covid-static/contents/data/daily-stats-v2.json: "Not Found"