### PR TITLE
change sql per CDPH

### DIFF
--- a/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/vaccine_doses.sql
+++ b/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/vaccine_doses.sql
@@ -1,5 +1,5 @@
 select
-HPIQUARTILE
-,count(vax_event_id)
-from CA_VACCINE.CA_VACCINE.TBL_DERIVED_BASE_DOSES_ADMIN
-group by 1
+    HPIQUARTILE
+    ,count(vax_event_id)
+from CA_VACCINE.CA_VACCINE.VW_DERIVED_BASE_DOSES_ADMIN
+group by 1;


### PR DESCRIPTION
Per Rui Zhao:

https://github.com/cagov/Cron/blob/master/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/vaccine_doses.sql This is the only query that uses the table rather than the view.
common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/vaccine_doses.sql
select
HPIQUARTILE
,count(vax_event_id)
from CA_VACCINE.CA_VACCINE.TBL_DERIVED_BASE_DOSES_ADMIN
group by 1
Show more
<https://github.com/cagov/Cron|cagov/Cron>cagov/Cron | Added by GitHub


There is a possibility that the view and table can show different numbers since the table is usually created once per day, and some times the source data is updated later on. This actually happened today, and the table was updated later on, but your HPI chart 2 has the old table's dated numbers.

In effect, your chart 2 right now doesn't agree with your SQL's output. So we recommend changing the SQL's source to the view, the only real difference is processing time as the table is quicker to load. Not sure if that matters.

so the new proposed SQL should be this:
select
    HPIQUARTILE
    ,count(vax_event_id)
from CA_VACCINE.CA_VACCINE.VW_DERIVED_BASE_DOSES_ADMIN
group by 1;