### PR TITLE
Bundling testingbot messages into single post

### DIFF
--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -1,22 +1,23 @@
 const { doCovidVaccineEquity } = require('./worker');
-const { slackBotChatPost, slackBotReportError } = require('../common/slackBot');
+const { slackBotChatPost, slackBotReportError, slackBotReplyPost, slackBotReactionAdd } = require('../common/slackBot');
 const notifyChannel = 'C01HTTNKHBM'; //covid19-vaccines
 const debugChannel = 'C01DBP67MSQ'; // testingbot
 
 module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   try {
-    await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 10:15am to 1:45pm)`);
+    const ts = (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 1:45pm)`)).json().ts;
 
     const PrResult = await doCovidVaccineEquity();
 
     if(PrResult) {
       const prMessage = `Vaccine equity data deployed\n${PrResult.html_url}`;
-      await slackBotChatPost(debugChannel,prMessage);
+      await slackBotReplyPost(debugChannel,ts,prMessage);
       await slackBotChatPost(notifyChannel,prMessage);
     }
 
-    await slackBotChatPost(debugChannel,`${appName} finished`);
+    await slackBotReplyPost(debugChannel,ts,`${appName} finished`);
+    await slackBotReactionAdd(debugChannel, ts, 'white_check_mark');
   } catch (e) {
     await slackBotReportError(debugChannel,`Error running ${appName}`,e,context,myTimer);
   }

--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -5,8 +5,9 @@ const debugChannel = 'C01DBP67MSQ'; // testingbot
 
 module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
+  let ts = null;
   try {
-    const ts = (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 1:45pm)`)).json().ts;
+    ts = (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 1:45pm)`)).json().ts;
 
     const PrResult = await doCovidVaccineEquity();
 
@@ -20,5 +21,10 @@ module.exports = async function (context, myTimer) {
     await slackBotReactionAdd(debugChannel, ts, 'white_check_mark');
   } catch (e) {
     await slackBotReportError(debugChannel,`Error running ${appName}`,e,context,myTimer);
+
+    if(ts) {
+      await slackBotReplyPost(debugChannel,ts,`${appName} ERROR!`);
+      await slackBotReactionAdd(debugChannel, ts, 'x');
+    }
   }
 };

--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -5,26 +5,26 @@ const debugChannel = 'C01DBP67MSQ'; // testingbot
 
 module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
-  let ts = null;
+  let slackPostTS = null;
   try {
-    ts = (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 1:45pm)`)).json().ts;
+    slackPostTS = (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 1:45pm)`)).json().ts;
 
     const PrResult = await doCovidVaccineEquity();
 
     if(PrResult) {
       const prMessage = `Vaccine equity data deployed\n${PrResult.html_url}`;
-      await slackBotReplyPost(debugChannel,ts,prMessage);
-      await slackBotChatPost(notifyChannel,prMessage);
+      await slackBotReplyPost(debugChannel, slackPostTS, prMessage);
+      await slackBotChatPost(notifyChannel, prMessage);
     }
 
-    await slackBotReplyPost(debugChannel,ts,`${appName} finished`);
-    await slackBotReactionAdd(debugChannel, ts, 'white_check_mark');
+    await slackBotReplyPost(debugChannel, slackPostTS,`${appName} finished`);
+    await slackBotReactionAdd(debugChannel, slackPostTS, 'white_check_mark');
   } catch (e) {
     await slackBotReportError(debugChannel,`Error running ${appName}`,e,context,myTimer);
 
-    if(ts) {
-      await slackBotReplyPost(debugChannel,ts,`${appName} ERROR!`);
-      await slackBotReactionAdd(debugChannel, ts, 'x');
+    if(slackPostTS) {
+      await slackBotReplyPost(debugChannel, slackPostTS, `${appName} ERROR!`);
+      await slackBotReactionAdd(debugChannel, slackPostTS, 'x');
     }
   }
 };


### PR DESCRIPTION
Trying this for vaccine equity first.

Slack debug messages should be one post per run with PR created and end time as replies.

Exception details should still post separately.