### PR TITLE
Adding sleep code before all PR approvals

### DIFF
--- a/CovidEquityData/index.js
+++ b/CovidEquityData/index.js
@@ -25,6 +25,8 @@ const appName = 'CovidEquityData';
 const sqlRootPath = "../SQL/CDT_COVID/Equity/";
 const schemaPath = `${sqlRootPath}schema/`;
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 // eslint-disable-next-line no-unused-vars
 module.exports = async function (context, functionInput) {
     try {
@@ -277,6 +279,7 @@ If there are issues with the data:
                 labels: PrLabels
             });
 
+            await sleep(5000); //give PR time to check actions
             //Approve Pr
             await gitRepo.mergePullRequest(Pr.number,{
                 merge_method: 'squash'

--- a/CovidStateDashboardV2/worker.js
+++ b/CovidStateDashboardV2/worker.js
@@ -14,6 +14,7 @@ const masterBranch = 'master';
 const nowPacTime = options => new Date().toLocaleString("en-CA", {timeZone: "America/Los_Angeles", ...options});
 const todayDateString = () => nowPacTime({year: 'numeric',month: '2-digit',day: '2-digit'});
 const todayTimeString = () => nowPacTime({hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'}).replace(/:/g,'-');
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * Check to see if we need stats update PRs, make them if we do.
@@ -38,6 +39,7 @@ const doCovidStateDashboarV2 = async () => {
             labels: PrLabels
         });
 
+        await sleep(5000); //let the PR check actions first
         await PrApprove(gitRepo,Pr);
     }
 

--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -14,6 +14,7 @@ const targetPath = 'data/vaccine-equity/';
 const nowPacTime = options => new Date().toLocaleString("en-CA", {timeZone: "America/Los_Angeles", ...options});
 const todayDateString = () => nowPacTime({year: 'numeric',month: '2-digit',day: '2-digit'});
 const todayTimeString = () => nowPacTime({hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'}).replace(/:/g,'-');
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const doCovidVaccineEquity = async () => {
     const gitModule = new GitHub({ token: process.env["GITHUB_TOKEN"] });
@@ -215,6 +216,7 @@ const doCovidVaccineEquity = async () => {
              labels: PrLabels
          });
 
+        await sleep(5000); //let the PR check actions before merging
         //Approve Pr
         await gitRepo.mergePullRequest(Pr.number,{
             merge_method: 'squash'

--- a/CovidVaccineHPIV2/worker.js
+++ b/CovidVaccineHPIV2/worker.js
@@ -16,6 +16,7 @@ const schemaPath = `../SQL/${SnowFlakeSqlPath}schema/`;
 const nowPacTime = options => new Date().toLocaleString("en-CA", { timeZone: "America/Los_Angeles", ...options });
 const todayDateString = () => nowPacTime({ year: 'numeric', month: '2-digit', day: '2-digit' });
 const todayTimeString = () => nowPacTime({ hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' }).replace(/:/g, '-');
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const doCovidVaccineHPIV2 = async () => {
   const gitModule = new GitHub({ token: process.env["GITHUB_TOKEN"] });
@@ -63,6 +64,7 @@ const doCovidVaccineHPIV2 = async () => {
 
   // Approve the PR
   if(Pr) {
+      await sleep(5000); //let the PR actions resolve first
       await gitRepo.mergePullRequest(Pr.number,{
           merge_method: 'squash'
       });

--- a/CovidWeeklyTierUpdate/doUpdate.js
+++ b/CovidWeeklyTierUpdate/doUpdate.js
@@ -12,7 +12,8 @@ const PrPrefix = 'Auto Tier Update';
 const branchPrefix = 'auto-tier-update';
 const commitMessage = 'update Tiers';
 const PrLabels = ['Automatic Deployment'];
- 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 const getData = async () => {
     const sqlResults = await queryDataset(getSQL('CDT_COVID/TierUpdate'),process.env["SNOWFLAKE_CDT_COVID"]);
 
@@ -94,6 +95,7 @@ const doWeeklyUpdatePrs = async mergetargets => {
                     report.push({Pr});
                 } else {
                     //Auto approve and delete non-master PRs
+                    await sleep(5000); //PR actions need time to check
                     await gitRepo.mergePullRequest(Pr.number,{
                         merge_method: 'squash'
                     });


### PR DESCRIPTION
Adding a 5 second delay before attempting to auto-approve PRs.  Should take care of 405 errors.