### PR TITLE
Adding Publish labels to avoid missing approvals

### DIFF
--- a/CovidTranslationPrApproval/AutoApprover.js
+++ b/CovidTranslationPrApproval/AutoApprover.js
@@ -55,6 +55,7 @@ const doAutoApprover = async () => {
                 await gitIssues.editIssue(Pr.number,{
                     labels
                 });
+                await sleep(5000); //let the label apply
             }
         }
     }

--- a/CovidTranslationPrApproval/AutoApprover.js
+++ b/CovidTranslationPrApproval/AutoApprover.js
@@ -9,6 +9,8 @@ const dataTimeZone = 'America/Los_Angeles';
 //const dataTimeZone = 'America/New_York';
 
 const AutoApproverLabels = require('./AutoApproverLabels.json').data;
+const labelPublishASAP = AutoApproverLabels.specialLabels.PublishASAP;
+const labelDoNotPublish = AutoApproverLabels.specialLabels.DoNotPublish;
 
 //Check to see if we need stats update PRs, make them if we do.
 const doAutoApprover = async () => {
@@ -19,11 +21,43 @@ const doAutoApprover = async () => {
 
     const gitModule = new GitHub({ token: process.env["GITHUB_TOKEN"] });
     const gitRepo = await gitModule.getRepo(githubUser,githubRepo);
+    const gitIssues = await gitModule.getIssues(githubUser,githubRepo);
     
-    let thisTime = moment().tz(dataTimeZone);
-    let thisHour = thisTime.hour();
-    let thisMinute = Math.floor(thisTime.minute() / 5) * 5; //Round down to 5 mins
-    let ActiveLabel = AutoApproverLabels.timeLabels.find(x=>x.hour===thisHour && x.minute===thisMinute)?.label;
+    moment.tz.setDefault(dataTimeZone); //So important when using Moment.JS
+
+    let ActiveLabel = AutoApproverLabels.timeLabels
+        .map(x=>({label:x.label,diff:moment()
+            .diff(moment().startOf('day')
+            .add(x.hour, 'hours')
+            .add(x.minute, 'minutes'),'minutes')}))
+        .find(x=>x.diff>0 && x.diff<15)
+        ?.label;
+
+    if(ActiveLabel) {
+        //Mark any Prs with the time publish label as publish asap
+        const PrsTimeReady = (await gitRepo.listPullRequests(
+            {
+                base : masterbranch
+            }
+            ))
+            .data
+            .filter(p=>
+                !p.draft //ignore drafts
+                &&p.labels.some(s=>s.name===ActiveLabel)
+            );
+
+        //Time is up.  Mark it for publishing (in case we miss it this pass)
+        for (const Pr of PrsTimeReady) {
+            //Add label to Pr
+            let labels = Pr.labels.map(x=>x.name); //Preserve existing labels!!!
+            if (!labels.includes(labelPublishASAP)) {
+                labels.push(labelPublishASAP);
+                await gitIssues.editIssue(Pr.number,{
+                    labels
+                });
+            }
+        }
+    }
 
     const Prs = (await gitRepo.listPullRequests(
         {
@@ -34,8 +68,8 @@ const doAutoApprover = async () => {
         .data
         .filter(p=>
             !p.draft //ignore drafts
-            &&p.labels.some(s=>s.name===ActiveLabel || s.name===AutoApproverLabels.specialLabels.PublishASAP)
-            &&!p.labels.some(s=>s.name===AutoApproverLabels.specialLabels.DoNotPublish)
+            &&p.labels.some(s=>s.name===labelPublishASAP) //Only incude marked for publishing
+            &&!p.labels.some(s=>s.name===labelDoNotPublish) //Hard exclude DoNots (Stop button)
         );
     for (const prlist of Prs) {
         //get the full pr detail
@@ -52,7 +86,10 @@ const doAutoApprover = async () => {
                 });
 
                 await gitRepo.deleteRef(`heads/${pr.head.ref}`);
-                await sleep(5000); //Wait after any approval so the next Pr can update
+
+                //This is where some notification should happen
+
+                await sleep(10000); //Wait after any approval so the next Pr can update
             }
         }
     }


### PR DESCRIPTION
The process will add the "PublishASAP" label to any PR that is ready to go.  That will ensure that they are deployed in the next run if there is a connection issue.

The process will only deploy "PublishASAP" labels, assuming the stop button label is off.