### PR TITLE
Vaccine Equity moved to static-data

### DIFF
--- a/CovidVaccineEquity/function.json
+++ b/CovidVaccineEquity/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineEquity",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 15/30 16-18 * * 3"
+      "schedule": "0 0 15 * * WED"
     }
   ]
 }

--- a/CovidVaccineEquity/function.json
+++ b/CovidVaccineEquity/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineEquity",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 15 * * WED"
+      "schedule": "0 0 15 * * Wed"
     }
   ]
 }

--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every 30 mins from 9:15am to 11:45pm)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (WED @ 8:00am)`)).json()).ts;
 
     const PrResult = await doCovidVaccineEquity();
 

--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -12,7 +12,7 @@ module.exports = async function (context, myTimer) {
     const PrResult = await doCovidVaccineEquity();
 
     if(PrResult) {
-      const prMessage = `Vaccine equity data deployed\n${PrResult.html_url}`;
+      const prMessage = `Vaccine equity data ready\n${PrResult.html_url}`;
       await slackBotReplyPost(debugChannel, slackPostTS, prMessage);
       await slackBotReactionAdd(debugChannel, slackPostTS, 'package');
       await slackBotChatPost(notifyChannel, prMessage);

--- a/CovidVaccineEquity/readme.md
+++ b/CovidVaccineEquity/readme.md
@@ -4,7 +4,7 @@ This service is used to retrieve data to populate the vaccination by race/ethnic
 
 - Data is retrieved from snowflake
 - Data is not published before the statewide coordinated daily stats release time 9:30am daily
-- Data is published as static json files to the covid-static(-data) repository and from there pushed to files.covid19.ca.gov
+- Data is published as static json files to the covid-static-data repository and from there pushed to files.covid19.ca.gov
 - FYI there is a 10 minute CDN cache on files deployed to files.covid19.ca.gov. The publishing flow does not yet invalidate this cache.
 - Data available on files.covid19.ca.gov is consumed by the charts on covid19.ca.gov pages with client side code and in the case of top box stats by the 11ty static site pregeneration build service to create the page HTML.
 

--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -1,14 +1,14 @@
 const { queryDataset } = require('../common/snowflakeQuery');
 const { validateJSON, validateJSON2, getSqlWorkAndSchemas } = require('../common/schemaTester');
 const GitHub = require('github-api');
-const PrLabels = ['Automatic Deployment'];
+const PrLabels = ['Automatic Deployment','Publish at 9:15 a.m. ☀️'];
 const githubUser = 'cagov';
-const githubRepo = 'covid-static';
+const githubRepo = 'covid-static-data';
 const committer = {
   name: process.env["GITHUB_NAME"],
   email: process.env["GITHUB_EMAIL"]
 };
-const masterBranch = 'master';
+const masterBranch = 'main';
 const sqlRootPath = "../SQL/CDTCDPH_VACCINE/CovidVaccineEquity/";
 const schemaPath = `${sqlRootPath}schema/`;
 const targetPath = 'data/vaccine-equity/';
@@ -16,7 +16,6 @@ const targetPath = 'data/vaccine-equity/';
 const nowPacTime = options => new Date().toLocaleString("en-CA", {timeZone: "America/Los_Angeles", ...options});
 const todayDateString = () => nowPacTime({year: 'numeric',month: '2-digit',day: '2-digit'});
 const todayTimeString = () => nowPacTime({hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'}).replace(/:/g,'-');
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const doCovidVaccineEquity = async () => {
     const gitModule = new GitHub({ token: process.env["GITHUB_TOKEN"] });
@@ -131,14 +130,6 @@ const doCovidVaccineEquity = async () => {
              labels: PrLabels
          });
 
-        await sleep(5000); //let the PR check actions before merging
-        //Approve Pr
-        await gitRepo.mergePullRequest(Pr.number,{
-            merge_method: 'squash'
-        });
-
-        //Delete Branch
-        await gitRepo.deleteRef(`heads/${Pr.head.ref}`);
         return Pr;
     }
 


### PR DESCRIPTION
Moving run to covid-static-data.  Building at Wed 8am, publishing at 9:15am.

For...
https://digital-ca-gov.atlassian.net/browse/CCG-2228

Test run here...
https://github.com/cagov/covid-static-data/pull/70

Remove this folder after merge...
https://github.com/cagov/covid-static/tree/master/data/vaccine-equity