### PR TITLE
moving CovidEquityData to new repo

### DIFF
--- a/CovidEquityData/readme.md
+++ b/CovidEquityData/readme.md
@@ -7,7 +7,7 @@ This service retrieves information to power the covid19 equity dashboard: <a hre
 
 - Data is retrieved from snowflake
 - Data is not published before the statewide coordinated daily stats release time 9:30am daily
-- Data is published as static json files to the covid-static(-data) repository and from there pushed to files.covid19.ca.gov
+- Data is published as static json files to the covid-static-data repository and from there pushed to files.covid19.ca.gov
 - Data will be initially published as an open pull request on the static repository. 
 - Data consumed by charts in staging is written into the /to-review folder. 
   - A PR is created and merged immediately for these json files.

--- a/CovidEquityData/worker.js
+++ b/CovidEquityData/worker.js
@@ -1,13 +1,13 @@
 const { queryDataset } = require('../common/snowflakeQuery');
 const { validateJSON, validateJSON2, getSqlWorkAndSchemas } = require('../common/schemaTester');
 const { todayDateString, todayTimeString, sleep } = require('../common/gitTreeCommon');
-const masterBranch = 'master';
+const masterBranch = 'main';
 const stagingFileLoc = 'data/to-review/equitydash/';
 const productionFileLoc = 'data/reviewed/equitydash/';
 const branchPrefix = 'data-';
 const GitHub = require('github-api');
 const githubUser = 'cagov';
-const githubRepo = 'covid-static';
+const githubRepo = 'covid-static-data';
 const committer = {
   name: process.env["GITHUB_NAME"],
   email: process.env["GITHUB_EMAIL"]


### PR DESCRIPTION
No workflow changes, since it writes to a staging folder anyway.

Have to wait till existing PR is approved before approving this one
https://github.com/cagov/covid-static/pull/673

(PR Approved...need to wait for data migration)
https://github.com/cagov/covid-static-data/pull/84

Remove these folders after deploying...
https://github.com/cagov/covid-static/tree/master/data/to-review
https://github.com/cagov/covid-static/tree/master/data/reviewed