### PR TITLE
Added daily averages to cases/deaths tables.

### DIFF
--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-cases.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-cases.json
@@ -126,6 +126,10 @@
                 "POPULATION": {
                   "required": true,
                   "type": "integer"
+                },
+                "CASES_DAILY_AVERAGE": {
+                  "required": true,
+                  "type": "number"
                 }
               }
             }

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-deaths.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-deaths.json
@@ -126,8 +126,12 @@
                 "POPULATION": {
                   "required": true,
                   "type": "integer"
+                },
+                "DEATHS_DAILY_AVERAGE": {
+                  "required": true,
+                  "type": "number"
                 }
-              }
+             }
             }
           }
         },


### PR DESCRIPTION
Comment: Currently when the data is processed, the DATE fields (which are simple YYYY-MM-DD) are converted into first-class date objects, and then converted back to the same string format for the json. This creates some ugliness -- in order to compare two dates I have resorted to a string-conversion since (a == b) doesn't work for dates. It would be better, in my opinion, to treat the dates as strings...  But I'm not gonna bother with it today.