### PR TITLE
Pipeline fixes for Wednesdays

### DIFF
--- a/CovidPostvaxData/worker.js
+++ b/CovidPostvaxData/worker.js
@@ -2,7 +2,7 @@ const { getData_daily_postvax_data } = require('./daily-postvax-data');
 
 const GitHub = require('github-api');
 const { createTreeFromFileMap, PrIfChanged, todayDateString } = require('../common/gitTreeCommon');
-const PrLabels = ['Automatic Deployment','Publish at 8:45 a.m. ☀️'];
+const PrLabels = ['Automatic Deployment','Publish at 8:30 a.m. ☀️'];
 const githubUser = 'cagov';
 const githubRepo = 'covid-static-data';
 const gitHubCommitter = {

--- a/CovidTranslationPrApproval/AutoApproverLabels.json
+++ b/CovidTranslationPrApproval/AutoApproverLabels.json
@@ -8,9 +8,24 @@
     "timeLabels":
     [
       {
+        "label":"Publish at 8:30 a.m. ☀️",
+        "hour":8,
+        "minute":30
+      },
+      {
+        "label":"Publish at 8:35 a.m. ☀️",
+        "hour":8,
+        "minute":35
+      },
+      {
         "label":"Publish at 8:40 a.m. ☀️",
         "hour":8,
         "minute":40
+      },
+      {
+        "label":"Publish at 8:45 a.m. ☀️",
+        "hour":8,
+        "minute":45
       },
       {
         "label":"Publish at 8:50 a.m. ☀️",
@@ -18,9 +33,19 @@
         "minute":50
       },
       {
+        "label":"Publish at 8:55 a.m. ☀️",
+        "hour":8,
+        "minute":55
+      },
+      {
         "label":"Publish at 9 a.m. ☀️",
         "hour":9,
         "minute":0
+      },
+      {
+        "label":"Publish at 9:05 a.m. ☀️",
+        "hour":9,
+        "minute":5
       },
       {
         "label":"Publish at 9:10 a.m. ☀️",
@@ -31,6 +56,11 @@
         "label":"Publish at 9:15 a.m. ☀️",
         "hour":9,
         "minute":15
+      },
+      {
+        "label":"Publish at 9:20 a.m. ☀️",
+        "hour":9,
+        "minute":20
       },
       {
         "label":"Publish at 10 a.m. ☀️",

--- a/CovidVaccineEquity/worker.js
+++ b/CovidVaccineEquity/worker.js
@@ -1,14 +1,14 @@
 const { queryDataset } = require('../common/snowflakeQuery');
 const { validateJSON, validateJSON2, getSqlWorkAndSchemas } = require('../common/schemaTester');
 const GitHub = require('github-api');
-const PrLabels = ['Automatic Deployment','Publish at 9:15 a.m. ☀️'];
+const PrLabels = ['Automatic Deployment','Publish at 8:35 a.m. ☀️'];
 const githubUser = 'cagov';
 const githubRepo = 'covid-static-data';
 const committer = {
   name: process.env["GITHUB_NAME"],
   email: process.env["GITHUB_EMAIL"]
 };
-const masterBranch = 'main';
+const targetBranch = 'preproduction';
 const sqlRootPath = "../SQL/CDTCDPH_VACCINE/CovidVaccineEquity/";
 const schemaPath = `${sqlRootPath}schema/`;
 const targetPath = 'data/vaccine-equity/';
@@ -97,7 +97,7 @@ const doCovidVaccineEquity = async () => {
 
     //function to return a new branch if the tree has changes
     const branchIfChanged = async (tree, branch, commitName) => {
-        const refResult = await gitRepo.getRef(`heads/${masterBranch}`);
+        const refResult = await gitRepo.getRef(`heads/${targetBranch}`);
         const baseSha = refResult.data.object.sha;
 
         console.log(`Creating tree for ${commitName}`);
@@ -110,7 +110,7 @@ const doCovidVaccineEquity = async () => {
         if (compare.data.files.length) {
             console.log(`${compare.data.files.length} changes.`);
             //Create a new branch and assign this commit to it, return the new branch.
-            await gitRepo.createBranch(masterBranch,branch);
+            await gitRepo.createBranch(targetBranch,branch);
             return await gitRepo.updateHead(`heads/${branch}`,commitSha);
         } else {
             console.log('no changes');
@@ -123,7 +123,7 @@ const doCovidVaccineEquity = async () => {
         const Pr = (await gitRepo.createPullRequest({
             title: PrTitle,
             head: BranchName,
-            base: masterBranch
+            base: targetBranch
         }))
         .data;
 

--- a/CovidVaccineHPIV2/worker.js
+++ b/CovidVaccineHPIV2/worker.js
@@ -1,7 +1,7 @@
 const { queryDataset, getSQL } = require('../common/snowflakeQuery');
 const { validateJSON } = require('../common/schemaTester');
 const GitHub = require('github-api');
-const PrLabels = ['Automatic Deployment','Publish at 8:50 a.m. ☀️'];
+const PrLabels = ['Automatic Deployment','Publish at 8:35 a.m. ☀️'];
 const githubUser = 'cagov';
 const githubRepo = 'covid-static-data';
 const committer = {


### PR DESCRIPTION
* Added all missing timing tags from 8:30 to 9:20 at 5 minute increments. We were missing 8:45, which was already in use and not triggering.

* Moved Wednesday merges to the 8:30-8:35 time frame, so they won't slow down the existing daily cadence (note that PR merges can only happen one per 5 minutes in the current system).

* Fixed VaccinesEquity to also merge to preproduction rather than main.