### PR TITLE
Restored missing code that triggered build.

### DIFF
--- a/CovidAutoBuilder/worker.js
+++ b/CovidAutoBuilder/worker.js
@@ -197,6 +197,10 @@ const doCovidAutoBuilder = async () => {
                         needsBuild = true;
                     }
                 });
+                if (needsBuild) {
+                    console.log("FORCING A BUILD");
+                    await force_build();
+                }
             } else {
                 console.log("VaccinesAdmin is 0, likely a parsing issue, report it");
                 errorEncountered = 'Failed to parse Vaccines from home page!';                


### PR DESCRIPTION
In my reimplementation of this 2 days ago, I dropped an important clause. - the part that, er, actually does the build.