### PR TITLE
Timing tweaks for 3 jobs.

### DIFF
--- a/CovidPostvaxData/function.json
+++ b/CovidPostvaxData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidPostvaxData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 45 15 * * Wed"
+        "schedule": "0 35 15 * * Wed"
       }
     ]
   }

--- a/CovidPostvaxData/index.js
+++ b/CovidPostvaxData/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:45am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:35am)`)).json()).ts;
 
     const PrResult = await doCovidPostvaxData();
 

--- a/CovidStateDashboardTables/function.json
+++ b/CovidStateDashboardTables/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTables",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 15 * * *"
+      "schedule": "0 20 15 * * *"
     }
   ]
 }

--- a/CovidStateDashboardTables/index.js
+++ b/CovidStateDashboardTables/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:00am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:20am)`)).json()).ts;
 
     const PrResults = await doCovidStateDashboardTables();
 

--- a/CovidStateDashboardVaccines/function.json
+++ b/CovidStateDashboardVaccines/function.json
@@ -4,7 +4,7 @@
         "name": "CovidStateDashboardVaccines",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 0 15 * * *"
+        "schedule": "0 5 15 * * *"
       }
     ]
   }

--- a/CovidStateDashboardVaccines/index.js
+++ b/CovidStateDashboardVaccines/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:00am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:05am)`)).json()).ts;
 
     const PrResult = await doCovidVaccinesSparklineData();
 


### PR DESCRIPTION
Changed timing on three jobs to meet 2 goals:

1) No concurrent jobs.

2) No jobs running exactly on the hour (when many people schedule their jobs).  We've had time-out issues with our longer 7am job.

![image](https://user-images.githubusercontent.com/287977/141204120-17a7ee91-885f-4420-8b02-044963ce94f4.png)


