### PR TITLE
Loosened rules on Vaccine HPI for a field we don't use.

### DIFF
--- a/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/schema/input/schema.json
+++ b/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/schema/input/schema.json
@@ -74,8 +74,7 @@
           },
           "VACCINATED_RATIO": {
             "type": "number",
-            "minimum": 0,
-            "maximum": 1
+            "minimum": 0
           },
           "PARTIALLY_VACCINATED_RATIO": {
             "type": "number",

--- a/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/schema/output/schema.json
+++ b/common/SQL/CDTCDPH_VACCINE/vaccine_hpi_v2/schema/output/schema.json
@@ -75,8 +75,7 @@
           },
           "VACCINATED_RATIO": {
             "type": "number",
-            "minimum": 0,
-            "maximum": 1
+            "minimum": 0
           },
           "PARTIALLY_VACCINATED_RATIO": {
             "type": "number",


### PR DESCRIPTION
The Vaccine HPI query failed today because a field we don't use VACCINE_RATIO exceeded 1.  Will have CDPH investigate what is going on, but turned off the "<= 1" requirement for now.  Ran the job locally with these settings to generate today's data.