### PR TITLE
Removed meta.PUBLISHED_DATE on StateDashboardTables files. 

### DIFF
--- a/CovidStateDashboardTables/worker.js
+++ b/CovidStateDashboardTables/worker.js
@@ -103,7 +103,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`patients/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {
@@ -133,7 +133,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`icu-beds/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {
@@ -204,7 +204,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`confirmed-cases/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {
@@ -231,7 +231,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`confirmed-deaths/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {
@@ -258,7 +258,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`total-tests/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {
@@ -283,7 +283,7 @@ const doCovidStateDashboardTables = async () => {
             allFilesMap.set(`positivity-rate/${regionFileName}.json`,
                 {
                     meta: {
-                        PUBLISHED_DATE: todayDateString(),
+                        // PUBLISHED_DATE: todayDateString(),
                         coverage: myRegion
                     },
                     data: {

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-cases.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-cases.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-deaths.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/confirmed-deaths.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/icu-beds.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/icu-beds.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/patients.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/patients.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/positivity-rate.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/positivity-rate.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"

--- a/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/total-tests.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTables/schema/output/total-tests.json
@@ -77,10 +77,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "PUBLISHED_DATE": {
-          "required": true,
-          "$ref": "#/definitions/date-YYYY-MM-DD"
-        },
         "coverage": {
           "required": true,
           "$ref": "#/definitions/county"


### PR DESCRIPTION
This is to prevent false PUBLISH_DATES on files which have unchanged data. 
We are now tracking publishing date for these files by tracking commits to github. Changing the publishing date for an otherwise unchanged file causes a false commit, and prevents us from tracking true changes, which we need to
track in order to display accurate dates on the State Dashboard.

At the moment, no-one is consu