### PR TITLE
Copying vaccine summary data into dashboard/vaccinations/sparklines.

### DIFF
--- a/CovidStateDashboardVaccines/daily-vaccines-sparkline.js
+++ b/CovidStateDashboardVaccines/daily-vaccines-sparkline.js
@@ -11,15 +11,17 @@ const getData_daily_vaccines_sparkline = async () => {
     fullyvaxedResults: getSQL('CDTCDPH_VACCINE/statedashboard-vaccines/fullyvaxed'),
     totalvaxedResults: getSQL('CDTCDPH_VACCINE/statedashboard-vaccines/totalvaxed'),
     populationResults: getSQL('CDTCDPH_VACCINE/statedashboard-vaccines/eligiblepopulation'),
-    dailyaverageResults: getSQL('CDTCDPH_VACCINE/statedashboard-vaccines/dailyaverage')
+    dailyaverageResults: getSQL('CDTCDPH_VACCINE/statedashboard-vaccines/dailyaverage'),
+    resultsVaccines: getSQL('CDTCDPH_VACCINE/Vaccines'),
   }
-  
+
   const {
     sparklineResults,
     fullyvaxedResults,
     totalvaxedResults,
     populationResults,
-    dailyaverageResults
+    dailyaverageResults,
+    resultsVaccines
   } = await queryDataset(sqlWork,process.env["SNOWFLAKE_CDTCDPH_VACCINE"]);
 
 
@@ -48,12 +50,17 @@ const getData_daily_vaccines_sparkline = async () => {
   let total_vaxed = totalvaxedResults[0].TOTAL_VACCINATED;
   let daily_average = dailyaverageResults[0].DAILY_AVG;
   let partially_vaxed = total_vaxed - fully_vaxed;
+  let rowVaccines = resultsVaccines[0];
   let json = {
       meta: {
         PUBLISHED_DATE: "1900-01-01",
         coverage: "California"
       },
       data: {
+        summary: {
+          DATE: mapped_sparkline_data[0].DATE,
+          CUMMULATIVE_DAILY_DOSES_ADMINISTERED : rowVaccines.CUMMULATIVE_DAILY_DOSES_ADMINISTERED
+        },
         population: {
           ELIGIBLE_POPULATION: eligible_pop,
           TOTAL_VAXED: total_vaxed,


### PR DESCRIPTION
This duplicates some vaccination-related data currently stored in data/daily-stats-v2.json into the file
data/dashboard/vaccines/sparkline.json.

The reason for this is the daily-stats-v2 file needs to run every day, due to the the presence of hospitalization and ICU data, which updates every day.  

However, at CDPH's request, we need to pause vaccination data publication on weekends.  
CDPH is still writing this data into snowflake, but we need to skip reading it on the days they don't wish to publish. 

So I'm moving the vaccination related summary data into a file that is vaccine related, and already being paused on weekends.

After CDPH stops referencing the vax data from daily-stats-v2.json on their page, I will stop including the data there.  For now, the data appears in both locations, until we get back in sync, likely later this week.

