### PR TITLE
Added snoozing feature for three daily jobs that don't run on weekends nor holidays.

### DIFF
--- a/CovidStateDashboardTablesCasesDeaths/function.json
+++ b/CovidStateDashboardTablesCasesDeaths/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesCasesDeaths",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 10 15 * * 1-5"
+      "schedule": "0 10 15 * * *"
     }
   ]
 }

--- a/CovidStateDashboardTablesCasesDeaths/index.js
+++ b/CovidStateDashboardTablesCasesDeaths/index.js
@@ -1,5 +1,6 @@
 const { doCovidStateDashboardTablesCasesDeaths } = require('./worker');
 const { slackBotChatPost, slackBotReportError, slackBotReplyPost, slackBotReactionAdd } = require('../common/slackBot');
+const { isIdleDay } = require('../common/timeOffCheck');
 //const notifyChannel = 'C01AA1ZB05B'; // #covid19-state-dash
 const debugChannel = 'C01DBP67MSQ'; // #testingbot
 
@@ -9,20 +10,26 @@ module.exports = async function (context, myTimer) {
   try {
     slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every weekday @ 7:10am)`)).json()).ts;
 
-    const PrResults = await doCovidStateDashboardTablesCasesDeaths();
+    if (isIdleDay({weekends_off:true, holidays_off:true})) {
+      await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);
+      await slackBotReactionAdd(debugChannel, slackPostTS, 'zzz');
+    }
+    else {
+      const PrResults = await doCovidStateDashboardTablesCasesDeaths();
 
-    if(PrResults) {
-      await slackBotReactionAdd(debugChannel, slackPostTS, 'package');
+      if(PrResults) {
+        await slackBotReactionAdd(debugChannel, slackPostTS, 'package');
 
-      for (let Pr of PrResults) {
-        await slackBotReplyPost(debugChannel, slackPostTS, Pr.html_url);
-        //removing notifications until final deployment
-        //await slackBotChatPost(notifyChannel, Pr.html_url);
+        for (let Pr of PrResults) {
+          await slackBotReplyPost(debugChannel, slackPostTS, Pr.html_url);
+          //removing notifications until final deployment
+          //await slackBotChatPost(notifyChannel, Pr.html_url);
+        }
       }
+      await slackBotReplyPost(debugChannel, slackPostTS,`${appName} finished`);
+      await slackBotReactionAdd(debugChannel, slackPostTS, 'white_check_mark');
     }
 
-    await slackBotReplyPost(debugChannel, slackPostTS,`${appName} finished`);
-    await slackBotReactionAdd(debugChannel, slackPostTS, 'white_check_mark');
   } catch (e) {
     await slackBotReportError(debugChannel,`Error running ${appName}`,e,context,myTimer);
 

--- a/CovidStateDashboardTablesTests/function.json
+++ b/CovidStateDashboardTablesTests/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesTests",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 30 15 * * 1-5"
+      "schedule": "0 30 15 * * *"
     }
   ]
 }

--- a/CovidStateDashboardVaccines/function.json
+++ b/CovidStateDashboardVaccines/function.json
@@ -4,7 +4,7 @@
         "name": "CovidStateDashboardVaccines",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 5 15 * * 1-5"
+        "schedule": "0 5 15 * * *"
       }
     ]
   }

--- a/common/timeOffCheck/index.js
+++ b/common/timeOffCheck/index.js
@@ -24,7 +24,7 @@ const isIdleDay = ({weekends_off = true, holidays_off = true}) => {
         return true;
     }
     return false;
-});
+};
 
 
 module.exports = {

--- a/common/timeOffCheck/index.js
+++ b/common/timeOffCheck/index.js
@@ -1,0 +1,32 @@
+
+const { todayDateString } = require('../common/gitTreeCommon');
+
+const cron_holidays = [
+            '2022-02-21', // presidents day
+            '2022-03-31', // cesar chavez day
+            '2022-05-30', // memorial day
+            '2022-07-04', // independence day
+            '2022-09-05', // labor day
+            '2022-11-11', // veterens day
+            '2022-11-24', // thanksgiving
+            '2022-11-25', // day after thanksgiving
+            '2022-12-25', // christmas
+            ]
+
+
+const isIdleDay = ({weekends_off = true, holidays_off = true}) => {
+    const todayDateStr = todayDateString();
+    const dayOfWeekIdx = (new Date()).getDay(); // sunday is zero
+    if (holidays_off && todayDateStr in cron_holidays) {
+        return true;
+    }
+    if (weekends_off && (dayOfWeekIdx == 0 || dayOfWeekIdx == 6)) {
+        return true;
+    }
+    return false;
+});
+
+
+module.exports = {
+    isIdleDay
+};


### PR DESCRIPTION
Currently, several Crons need pausing on both week-days, and holidays. Currently we are only pausing on weekdays, via the Cron-timing specification in functions.json, and holidays require manual intervention.  The intent of this patch is to reduce day-of-execution interventions.  It also provides explanatory messages to the testing channel when jobs are skipped for the day.

This modification adds a lookup function **_isIdleDay_**, used to determine if a job should run or not. The function returns _true_ if it's a weekend or holiday.  Such a job is considered "snoozed" for the day and gets a :zzz: emoji instead of a checkmark.  The three jobs that will use this feature are set to run every day in this patch, instead of Mon-Fri, as before, so that there are more informative messages on weekends.

It is unclear at this point if the CDPH holiday schedule will be identical to the state holiday schedule (especially for Cesar Chavez day, which falls on a Thursday), so I am storing the holiday list locally, in this patch, rather than consulting the alpha API, which may not be a reliable indicator.  

The stored holiday list is complete through the end of 2020.
