### PR TITLE
Added preview-only version of CovidVariantsData.

### DIFF
--- a/CovidVariantsData/worker.js
+++ b/CovidVariantsData/worker.js
@@ -15,7 +15,7 @@ const targetBranch = 'main';
  * Check to see if we need stats update PRs, make them if we do.
  * @returns The PR created if changes were made
  */
-const doCovidVariantsData = async () => {
+const doCovidVariantsData = async (previewOnly) => {
     const gitToken = process.env["GITHUB_TOKEN"];
     const prTitle = `${todayDateString()} Variants Data Update`;
 
@@ -40,30 +40,32 @@ const doCovidVariantsData = async () => {
     });
 
     stagingTree.syncFile(fileName, jsonData);
-    await stagingTree.treePush();
-
+    const stagingResult = await stagingTree.treePush();
 
     //Production will be PRs
-    const mainTree = new GitHubTreePush(gitToken, {
-        owner: githubOwner,
-        repo: githubRepo,
-        path: githubPath,
-        base: targetBranch,
-        removeOtherFiles: true,
-        commit_message: prTitle,
-        pull_request: true,
-        pull_request_options: {
-            title: prTitle,
-            issue_options: {
-                labels: PrLabels
+    if (!previewOnly) {
+        const mainTree = new GitHubTreePush(gitToken, {
+            owner: githubOwner,
+            repo: githubRepo,
+            path: githubPath,
+            base: targetBranch,
+            removeOtherFiles: true,
+            commit_message: prTitle,
+            pull_request: true,
+            pull_request_options: {
+                title: prTitle,
+                issue_options: {
+                    labels: PrLabels
+                }
             }
-        }
-    });
+        });
 
-    mainTree.syncFile(fileName, jsonData);
-    const mainResult = await mainTree.treePush();
-
-    return mainResult;
+        mainTree.syncFile(fileName, jsonData);
+        const mainResult = await mainTree.treePush();
+        return mainResult;
+    } else {
+        return stagingResult;
+    }
 };
 
 module.exports = {

--- a/CovidVariantsDataPreview/function.json
+++ b/CovidVariantsDataPreview/function.json
@@ -1,0 +1,10 @@
+{
+    "bindings": [
+      {
+        "name": "CovidVariantsDataPreview",
+        "type": "timerTrigger",
+        "direction": "in",
+        "schedule": "0 0 21-23 * * Wed"
+      }
+    ]
+  }

--- a/CovidVariantsDataPreview/index.js
+++ b/CovidVariantsDataPreview/index.js
@@ -1,5 +1,5 @@
 
-const { doCovidVariantsData } = require('./worker');
+const { doCovidVariantsData } = require('../CovidVariantsData/worker'); // this piggy-backs off of CovidVariantsData
 const { slackBotChatPost, slackBotReportError, slackBotReplyPost, slackBotReactionAdd } = require('../common/slackBot');
 const notifyChannel = 'C01AA1ZB05B'; // #covid19-state-dash
 const debugChannel = 'C01DBP67MSQ'; // #testingbot
@@ -8,9 +8,9 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:55am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 1pm,2pm,3pm)`)).json()).ts;
 
-    const TreeRunResults = await doCovidVariantsData(false);
+    const TreeRunResults = await doCovidVariantsData(true);
 
     if (TreeRunResults.Pull_Request_URL) {
       const prMessage = `Weekly Variants data ready\n${TreeRunResults.Pull_Request_URL}`;

--- a/CovidVariantsDataPreview/readme.md
+++ b/CovidVariantsDataPreview/readme.md
@@ -1,0 +1,7 @@
+# Date pipeline for covid19.ca.gov variants chart
+
+This service is used to retrieve data to populate the variants chart on the  <a href="https://covid19.ca.gov/variants/#in-california">variants page</a>
+
+This version of the service only provides a staging preview, and is run several times, the day before the chart is published.
+[ TBD ]
+

--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -86,11 +86,15 @@ const doWork = async opt => {
         console.log("Running doCovidVaccinesSparklineData");
         await doCovidVaccinesSparklineData();
         break;
-    case '16':
+    case '16main':
         console.log("Running doCovidVariantsData");
-        await doCovidVariantsData();
+        await doCovidVariantsData(false);
         break;
-    case 'temp':
+    case '16preview':
+        console.log("Running doCovidVariantsDataPreview");
+        await doCovidVariantsData(true);
+        break;
+        case 'temp':
         //Put some temporary code here
         console.log("Running Temp code");
         


### PR DESCRIPTION
The CovidVariantsData job, which pulls data for the Variants chart, runs on Thursday morning.

We generally preview this chart on Wednesday afternoons, and I have been doing manual runs to produce these previews, while re-tagging/removing the resultant PRs.

This patch adds a second Trigger function CovidVariantsDataPreview, which piggy-backs off the code in CovidVariantsData, but updates the CovidStateDashboardVariants_Staging branch only without submitting a PR to master.

The workhorse function now receives a parameter, previewOnly which is used to inhibit the PR to master part of the task.

This new trigger is currently scheduled to run at 1pm, 2pm and 3pm on Wednesday.  This triggering will be refined when we get a more reliable update schedule.
