### PR TITLE
OAuth account support for Snowflake Connections

### DIFF
--- a/CovidAutoBuilder/function.json
+++ b/CovidAutoBuilder/function.json
@@ -4,7 +4,7 @@
         "name": "CovidAutoBuilder",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 25 16 * * *"
+        "schedule": "0 25 16 * * Tue,Fri"
       }
     ]
   }

--- a/CovidAutoBuilder/package-lock.json
+++ b/CovidAutoBuilder/package-lock.json
@@ -115,9 +115,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -360,9 +360,9 @@
       "integrity": "sha512-FUc9XZuhyE3ka3m53lec29PXVhdRf59QG01nE+OZdfl0M/R0E7Pk6k6qeWzHhX1pHl/f2JPA97sjjbHRgSg/9A=="
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "htmlparser2": {
       "version": "3.10.1",

--- a/CovidEquityData/worker.js
+++ b/CovidEquityData/worker.js
@@ -45,7 +45,7 @@ If there are issues with the data:
         
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath,'schema/[file]/input/schema.json','schema/[file]/input/sample.json','schema/[file]/input/fail/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork,process.env["SNOWFLAKE_CDT_COVID"]);
 
     Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
         const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidEquityData/worker.js
+++ b/CovidEquityData/worker.js
@@ -45,7 +45,7 @@ If there are issues with the data:
         
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath,'schema/[file]/input/schema.json','schema/[file]/input/sample.json','schema/[file]/input/fail/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork,process.env["SNOWFLAKE_CDT_COVID"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
 
     Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
         const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidPostvaxData/daily-postvax-data.js
+++ b/CovidPostvaxData/daily-postvax-data.js
@@ -11,7 +11,7 @@ const getData_daily_postvax_data = async () => {
       {
           postvax_data: getSQL('CDT_COVID/postvax-data/Postvax'),
       }
-      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
+      ,process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]
   );
 
   const report_date = statResults.postvax_data[0].REPORT_DATE;

--- a/CovidPostvaxData/daily-postvax-data.js
+++ b/CovidPostvaxData/daily-postvax-data.js
@@ -11,7 +11,7 @@ const getData_daily_postvax_data = async () => {
       {
           postvax_data: getSQL('CDT_COVID/postvax-data/Postvax'),
       }
-      ,process.env["SNOWFLAKE_CDT_COVID"]
+      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
   );
 
   const report_date = statResults.postvax_data[0].REPORT_DATE;

--- a/CovidPostvaxData/function.json
+++ b/CovidPostvaxData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidPostvaxData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 35 14 * * Wed"
+        "schedule": "0 35 14 * * Fri"
       }
     ]
   }

--- a/CovidPostvaxData/index.js
+++ b/CovidPostvaxData/index.js
@@ -8,9 +8,9 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:35am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 7:35am)`)).json()).ts;
 
-    const TreeRunResults = await doCovidPostvaxData();
+    const TreeRunResults = await doCovidPostvaxData(false);
 
     if(TreeRunResults.Pull_Request_URL) {
       const prMessage = `Weekly Postvax data ready\n${TreeRunResults.Pull_Request_URL}`;

--- a/CovidPostvaxData/worker.js
+++ b/CovidPostvaxData/worker.js
@@ -14,7 +14,7 @@ const targetBranch = 'main';
  * Check to see if we need stats update PRs, make them if we do.
  * @returns The PR created if changes were made
  */
-const doCovidPostvaxData = async () => {
+const doCovidPostvaxData = async (previewOnly) => {
     const gitToken = process.env["GITHUB_TOKEN"];
     const prTitle = `${todayDateString()} Postvax Data Update`;
 
@@ -31,28 +31,32 @@ const doCovidPostvaxData = async () => {
     });
 
     stagingTree.syncFile(fileName, jsonData);
-    await stagingTree.treePush();
+    const stagingResult = await stagingTree.treePush();
 
-    const mainTree = new GitHubTreePush(gitToken, {
-        owner: githubOwner,
-        repo: githubRepo,
-        path: githubPath,
-        base: targetBranch,
-        removeOtherFiles: true,
-        commit_message: prTitle,
-        pull_request: true,
-        pull_request_options: {
-            title: prTitle,
-            issue_options: {
-                labels: PrLabels
+    if (!previewOnly) {
+        const mainTree = new GitHubTreePush(gitToken, {
+            owner: githubOwner,
+            repo: githubRepo,
+            path: githubPath,
+            base: targetBranch,
+            removeOtherFiles: true,
+            commit_message: prTitle,
+            pull_request: true,
+            pull_request_options: {
+                title: prTitle,
+                issue_options: {
+                    labels: PrLabels
+                }
             }
-        }
-    });
+        });
 
-    mainTree.syncFile(fileName, jsonData);
-    const mainResult = await mainTree.treePush();
+        mainTree.syncFile(fileName, jsonData);
+        const mainResult = await mainTree.treePush();
 
-    return mainResult;
+        return mainResult;
+    } else {
+        return stagingResult;
+    }
 };
 
 module.exports = {

--- a/CovidPostvaxDataPreview/function.json
+++ b/CovidPostvaxDataPreview/function.json
@@ -1,0 +1,10 @@
+{
+    "bindings": [
+      {
+        "name": "CovidPostvaxDataPreview",
+        "type": "timerTrigger",
+        "direction": "in",
+        "schedule": "0 30 23 * * Tue"
+      }
+    ]
+  }

--- a/CovidPostvaxDataPreview/index.js
+++ b/CovidPostvaxDataPreview/index.js
@@ -1,0 +1,32 @@
+
+const { doCovidPostvaxData } = require('../CovidPostvaxData/worker');
+const { slackBotChatPost, slackBotReportError, slackBotReplyPost, slackBotReactionAdd } = require('../common/slackBot');
+const notifyChannel = 'C01AA1ZB05B'; // #covid19-state-dash
+const debugChannel = 'C01DBP67MSQ'; // #testingbot
+
+module.exports = async function (context, myTimer) {
+  const appName = context.executionContext.functionName;
+  let slackPostTS = null;
+  try {
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tuesday @ 4:30pm)`)).json()).ts;
+
+    const TreeRunResults = await doCovidPostvaxData(true);
+
+    if(TreeRunResults.Pull_Request_URL) {
+      const prMessage = `Weekly Postvax preview data ready\n${TreeRunResults.Pull_Request_URL}`;
+      await slackBotReplyPost(debugChannel, slackPostTS, prMessage);
+      await slackBotReactionAdd(debugChannel, slackPostTS, 'package');
+      await slackBotChatPost(notifyChannel, prMessage);
+    }
+
+    await slackBotReplyPost(debugChannel, slackPostTS,`${appName} finished`);
+    await slackBotReactionAdd(debugChannel, slackPostTS, 'white_check_mark');
+  } catch (e) {
+    await slackBotReportError(debugChannel,`Error running ${appName}`,e,context,myTimer);
+
+    if(slackPostTS) {
+      await slackBotReplyPost(debugChannel, slackPostTS, `${appName} ERROR!`);
+      await slackBotReactionAdd(debugChannel, slackPostTS, 'x');
+    }
+  }
+};

--- a/CovidPostvaxDataPreview/readme.md
+++ b/CovidPostvaxDataPreview/readme.md
@@ -1,0 +1,6 @@
+# Date pipeline for covid19.ca.gov state dashboard
+
+This service is used to retrieve data to populate the post-vax charts on the covid19.ca.gov homepage and the <a href="https://covid19.ca.gov/state-dashboard/">state dashboard</a>
+
+This version of the service only provides a staging preview.
+

--- a/CovidStateDashboardSummary/daily-stats-v2.js
+++ b/CovidStateDashboardSummary/daily-stats-v2.js
@@ -17,7 +17,7 @@ const getData_daily_stats_v2 = async () => {
           metrics: getSQL('CDT_COVID/Daily-stats-v2/Metrics'),
           hospitalizations : getSQL('CDT_COVID/Daily-stats-v2/Hospitalizations')
       }
-      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
+      ,process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]
   );
 //   const resultsVaccines = await queryDataset(
 //       getSQL('CDTCDPH_VACCINE/Vaccines'),

--- a/CovidStateDashboardSummary/daily-stats-v2.js
+++ b/CovidStateDashboardSummary/daily-stats-v2.js
@@ -17,7 +17,7 @@ const getData_daily_stats_v2 = async () => {
           metrics: getSQL('CDT_COVID/Daily-stats-v2/Metrics'),
           hospitalizations : getSQL('CDT_COVID/Daily-stats-v2/Hospitalizations')
       }
-      ,process.env["SNOWFLAKE_CDT_COVID"]
+      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
   );
 //   const resultsVaccines = await queryDataset(
 //       getSQL('CDTCDPH_VACCINE/Vaccines'),

--- a/CovidStateDashboardSummary/function.json
+++ b/CovidStateDashboardSummary/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardSummary",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 45 14 * * *"
+      "schedule": "0 45 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardSummary/index.js
+++ b/CovidStateDashboardSummary/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:45am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:45am)`)).json()).ts;
 
     const TreeRunResults = await doCovidStateDashboardSummary();
 

--- a/CovidStateDashboardSummary/infections-by-group.js
+++ b/CovidStateDashboardSummary/infections-by-group.js
@@ -13,7 +13,7 @@ const getData_infections_by_group = async () => {
       {
           infections_by_group : getSQL('CDT_COVID/Infections-by-group/infections-by-group')
       }
-      ,process.env["SNOWFLAKE_CDT_COVID"]
+      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
   );
 
   const arrayResultMap = m => ({CATEGORY:m.CATEGORY,METRIC_VALUE:m.METRIC_VALUE});

--- a/CovidStateDashboardSummary/infections-by-group.js
+++ b/CovidStateDashboardSummary/infections-by-group.js
@@ -13,7 +13,7 @@ const getData_infections_by_group = async () => {
       {
           infections_by_group : getSQL('CDT_COVID/Infections-by-group/infections-by-group')
       }
-      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
+      ,process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]
   );
 
   const arrayResultMap = m => ({CATEGORY:m.CATEGORY,METRIC_VALUE:m.METRIC_VALUE});

--- a/CovidStateDashboardTablesCasesDeaths/function.json
+++ b/CovidStateDashboardTablesCasesDeaths/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesCasesDeaths",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 10 14 * * *"
+      "schedule": "0 10 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesCasesDeaths/index.js
+++ b/CovidStateDashboardTablesCasesDeaths/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every weekday @ 7:10am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:10am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardTablesCasesDeaths/worker.js
+++ b/CovidStateDashboardTablesCasesDeaths/worker.js
@@ -65,7 +65,7 @@ const doCovidStateDashboardTablesCasesDeaths = async () => {
 
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]);
     if (doInputValidation) {
         Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
             const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidStateDashboardTablesCasesDeaths/worker.js
+++ b/CovidStateDashboardTablesCasesDeaths/worker.js
@@ -65,7 +65,7 @@ const doCovidStateDashboardTablesCasesDeaths = async () => {
 
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
     if (doInputValidation) {
         Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
             const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidStateDashboardTablesHospitals/function.json
+++ b/CovidStateDashboardTablesHospitals/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesHospitals",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 20 14 * * *"
+      "schedule": "0 20 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesHospitals/index.js
+++ b/CovidStateDashboardTablesHospitals/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every day @ 7:20am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:20am)`)).json()).ts;
 
     const PrResults = await doCovidStateDashboardTablesHospitals();
 

--- a/CovidStateDashboardTablesHospitals/worker.js
+++ b/CovidStateDashboardTablesHospitals/worker.js
@@ -66,7 +66,7 @@ const doCovidStateDashboardTablesHospitals = async () => {
 
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
     if (doInputValidation) {
         Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
             const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidStateDashboardTablesHospitals/worker.js
+++ b/CovidStateDashboardTablesHospitals/worker.js
@@ -66,7 +66,7 @@ const doCovidStateDashboardTablesHospitals = async () => {
 
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]);
     if (doInputValidation) {
         Object.keys(sqlWorkAndSchemas.schema).forEach(file => {
             const schemaObject = sqlWorkAndSchemas.schema[file];

--- a/CovidStateDashboardTablesTests/function.json
+++ b/CovidStateDashboardTablesTests/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesTests",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 30 14 * * *"
+      "schedule": "0 30 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesTests/index.js
+++ b/CovidStateDashboardTablesTests/index.js
@@ -29,7 +29,7 @@ module.exports = async function (context) {
   const slack = new SlackConnector(slackBotGetToken(), debugChannel, {username:slackBotName});
 
   try {
-    await slack.Chat(`${appName} (Every weekday @ 7:30am)`);
+    await slack.Chat(`${appName} (Every Tue,Fri @ 7:30am)`);
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slack.Reply(`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardTablesTests/worker.js
+++ b/CovidStateDashboardTablesTests/worker.js
@@ -80,7 +80,7 @@ const doCovidStateDashboardTablesTests = async (slack) => {
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
     await slackIfConnected(slack, 'Running queries...');
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
     if (doInputValidation) {
         await slackIfConnected(slack, 'Validating input...');
 

--- a/CovidStateDashboardTablesTests/worker.js
+++ b/CovidStateDashboardTablesTests/worker.js
@@ -80,7 +80,7 @@ const doCovidStateDashboardTablesTests = async (slack) => {
     const sqlWorkAndSchemas = getSqlWorkAndSchemas(sqlRootPath, 'schema/input/[file]/schema.json', 'schema/input/[file]/sample.json', 'schema/input/[file]/fail/', 'schema/output/');
 
     await slackIfConnected(slack, 'Running queries...');
-    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDT_COVID_OAUTH"]);
+    const allData = await queryDataset(sqlWorkAndSchemas.DbSqlWork, process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]);
     if (doInputValidation) {
         await slackIfConnected(slack, 'Validating input...');
 

--- a/CovidStateDashboardVaccines/function.json
+++ b/CovidStateDashboardVaccines/function.json
@@ -4,7 +4,7 @@
         "name": "CovidStateDashboardVaccines",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 5 14 * * *"
+        "schedule": "0 5 14 * * Tue,Fri"
       }
     ]
   }

--- a/CovidStateDashboardVaccines/index.js
+++ b/CovidStateDashboardVaccines/index.js
@@ -10,7 +10,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every weekday @ 7:05am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:05am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidVaccineEquity/function.json
+++ b/CovidVaccineEquity/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineEquity",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 50 14 * * Wed"
+      "schedule": "0 50 14 * * Fri"
     }
   ]
 }

--- a/CovidVaccineEquity/index.js
+++ b/CovidVaccineEquity/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:50am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 7:50am)`)).json()).ts;
 
     const PrResult = await doCovidVaccineEquity();
 

--- a/CovidVaccineHPIV2/function.json
+++ b/CovidVaccineHPIV2/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineHPIV2",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 5 15 * * Wed"
+      "schedule": "0 5 15 * * Fri"
     }
   ]
 }

--- a/CovidVaccineHPIV2/index.js
+++ b/CovidVaccineHPIV2/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 8:05am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 8:05am)`)).json()).ts;
 
     const PrResult = await doCovidVaccineHPIV2();
 

--- a/CovidVariantsData/function.json
+++ b/CovidVariantsData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 55 14 * * Thu"
+        "schedule": "0 55 14 * * Fri"
       }
     ]
   }

--- a/CovidVariantsData/index.js
+++ b/CovidVariantsData/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:55am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 7:55am)`)).json()).ts;
 
     const TreeRunResults = await doCovidVariantsData(false);
 

--- a/CovidVariantsData/weekly-variants-data.js
+++ b/CovidVariantsData/weekly-variants-data.js
@@ -11,7 +11,7 @@ const getData_weekly_variants_data = async () => {
       {
           variants_data: getSQL('CDT_COVID/variants-data/Variants'),
       }
-      ,process.env["SNOWFLAKE_CDT_COVID"]
+      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
   );
 
   // validateJSON('CDTCDPH_VACCINE/Vaccines.sql failed validation', resultsVaccines,'../SQL/CDTCDPH_VACCINE/Vaccines.sql.Schema.json','../SQL/CDTCDPH_VACCINE/Vaccines.sql.Sample.json');

--- a/CovidVariantsData/weekly-variants-data.js
+++ b/CovidVariantsData/weekly-variants-data.js
@@ -11,7 +11,7 @@ const getData_weekly_variants_data = async () => {
       {
           variants_data: getSQL('CDT_COVID/variants-data/Variants'),
       }
-      ,process.env["SNOWFLAKE_CDT_COVID_OAUTH"]
+      ,process.env["SNOWFLAKE_CDTCDPH_COVID_OAUTH"]
   );
 
   // validateJSON('CDTCDPH_VACCINE/Vaccines.sql failed validation', resultsVaccines,'../SQL/CDTCDPH_VACCINE/Vaccines.sql.Schema.json','../SQL/CDTCDPH_VACCINE/Vaccines.sql.Sample.json');

--- a/CovidVariantsDataPreview/function.json
+++ b/CovidVariantsDataPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsDataPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 50 19-22 * * Wed"
+        "schedule": "0 50 19-22 * * Wed,Fri"
       }
     ]
   }

--- a/CovidVariantsDataPreview/index.js
+++ b/CovidVariantsDataPreview/index.js
@@ -13,7 +13,7 @@ module.exports = async function (context, myTimer) {
     const TreeRunResults = await doCovidVariantsData(true);
 
     if (TreeRunResults.Pull_Request_URL) {
-      const prMessage = `Weekly Variants data ready\n${TreeRunResults.Pull_Request_URL}`;
+      const prMessage = `Weekly Variants preview data ready\n${TreeRunResults.Pull_Request_URL}`;
       await slackBotReplyPost(debugChannel, slackPostTS, prMessage);
       await slackBotReactionAdd(debugChannel, slackPostTS, 'package');
       await slackBotChatPost(notifyChannel, prMessage);

--- a/common/snowflakeQuery/index.js
+++ b/common/snowflakeQuery/index.js
@@ -45,6 +45,10 @@ const queryDataset = async (sqlWork, connection) => {
         ConnectionOptionsObj.authenticator = 'OAUTH';
         ConnectionOptionsObj.client_session_keep_alive = true;
         ConnectionOptionsObj.max_connection_pool = 20;
+        // delete this for security
+        if ('password' in ConnectionOptionsObj) {
+            delete ConnectionOptionsObj['password'];
+        }
     }
 
     console.log("Getting Connection");
@@ -154,8 +158,10 @@ const getDatabaseConnection = (ConnectionOptions) => {
         return ConnectionOptionsObj;
     }
 
-    if (!ConnectionOptionsObj.username || !ConnectionOptionsObj.password || !ConnectionOptionsObj.account | !ConnectionOptionsObj.warehouse) {
-        throw new Error('You need local.settings.json to contain a JSON connection string {account,warehouse,username,password} to use the dataset features');
+    if ((!ConnectionOptionsObj.token && !ConnectionOptionsObj.password) ||
+        !ConnectionOptionsObj.username ||
+        !ConnectionOptionsObj.account || !ConnectionOptionsObj.warehouse) {
+        throw new Error('You need local.settings.json to contain a JSON connection string {account,warehouse,username,password/token} to use the dataset features');
     }
 
     const connection = snowflake.createConnection(ConnectionOptionsObj);

--- a/common/snowflakeQuery/index.js
+++ b/common/snowflakeQuery/index.js
@@ -45,19 +45,6 @@ const queryDataset = async (sqlWork, connection) => {
         ConnectionOptionsObj.authenticator = 'OAUTH';
         ConnectionOptionsObj.client_session_keep_alive = true;
         ConnectionOptionsObj.max_connection_pool = 20;
-
-        // ConnectionsOptionsObj = {
-        //     'account':ConnectionOptionsObj.account,
-        //     'schema':ConnectionOptionsObj.schema,
-        //     'database':ConnectionOptionsObj.database,
-        //     'warehouse':ConnectionOptionsObj.warehouse,
-        //     'role':ConnectionOptionsObj.role,
-        //     'username':ConnectionOptionsObj.username, // not used...
-        //     'authenticator':'oauth',
-        //     'token':token,
-        //     'client_session_keep_alive':"True",
-        //     'max_connection_pool':20
-        // };
     }
 
     console.log("Getting Connection");
@@ -113,6 +100,12 @@ const getDbPromise = (connection, name, sqlText) => new Promise((resolve, reject
     });
 });
 
+/**
+ * Fetches an OAuth token using the supplied connection parameters.
+ * @param {*} ConnectionOptionsObj 
+ * @returns 
+ */
+
 const getToken = async (ConnectionOptionsObj) => {
     const AUTH_GRANT_TYPE = 'password';
     const SCOPE_URL = "https://1ac25458-542c-4ecb-8105-36c15005b656/session:role-any";
@@ -135,9 +128,7 @@ const getToken = async (ConnectionOptionsObj) => {
     }
     const payload = elems.join('&');
 
-    // note: this payload is working if the console-output is pasted into my python script
-    // or to CURL, however when using javascript/fetch it produces an error that 'grant_type' is missing.
-    // console.log("Fetching Token, payload =", payload);
+    // note: the token service does NOT appear to support application/json for the payload.
     return fetch(TOKEN_URL, {
           method: "POST",
           headers: HEADERS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,9 +1150,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -5403,9 +5403,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,9 +1728,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -5854,9 +5854,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,9 +2955,9 @@
       }
     },
     "node_modules/nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -6812,9 +6812,9 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "requires": {
         "boolbase": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2947,9 +2947,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "engines": {
         "node": ">=8"
       }
@@ -6807,9 +6807,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
     },
     "nth-check": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2836,9 +2836,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -6721,9 +6721,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4332,11 +4332,23 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -7921,9 +7933,10 @@
       }
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,9 +1299,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-      "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
       "engines": {
         "node": ">= 6"
       },
@@ -5527,9 +5527,9 @@
       }
     },
     "css-what": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-      "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
     },
     "cssom": {
       "version": "0.4.4",

--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -80,17 +80,21 @@ const doWork = async opt => {
         break;
     case '14':
         console.log("Running doCovidPostvaxData");
-        await doCovidPostvaxData();
+        await doCovidPostvaxData(false);
+        break;
+    case '14p':
+        console.log("Running doCovidPostvaxDataPreview");
+        await doCovidPostvaxData(true);
         break;
     case '15':
         console.log("Running doCovidVaccinesSparklineData");
         await doCovidVaccinesSparklineData();
         break;
-    case '16main':
+    case '16':
         console.log("Running doCovidVariantsData");
         await doCovidVariantsData(false);
         break;
-    case '16preview':
+    case '16p':
         console.log("Running doCovidVariantsDataPreview");
         await doCovidVariantsData(true);
         break;


### PR DESCRIPTION
This supports Open Auth connections using a new account to cdtcdph.west, to replace all the connections to cdt.west.

It required updating snowflake-api from 1.5.3 to 1.6.8 in order to work properly.  I've made this switch on master, since it doesn't appear to affect the existing code in my tests.

It has been successfully tested locally.

It will require adding the new SNOWFLAKE_CDT_COVID_OAUTH connection string to the Azure secrets. (DONE)  

I also need to make sure that CDPH is ready to switch over before merging this.

