### PR TITLE
Changed daily crons to Tue/Fri.  Changed most weekly crons to Fri only.

### DIFF
--- a/CovidAutoBuilder/function.json
+++ b/CovidAutoBuilder/function.json
@@ -4,7 +4,7 @@
         "name": "CovidAutoBuilder",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 25 16 * * *"
+        "schedule": "0 25 16 * * Tue,Fri"
       }
     ]
   }

--- a/CovidPostvaxData/function.json
+++ b/CovidPostvaxData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidPostvaxData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 35 14 * * Wed"
+        "schedule": "0 35 14 * * Fri"
       }
     ]
   }

--- a/CovidStateDashboardSummary/function.json
+++ b/CovidStateDashboardSummary/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardSummary",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 45 14 * * *"
+      "schedule": "0 45 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesCasesDeaths/function.json
+++ b/CovidStateDashboardTablesCasesDeaths/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesCasesDeaths",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 10 14 * * *"
+      "schedule": "0 10 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesHospitals/function.json
+++ b/CovidStateDashboardTablesHospitals/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesHospitals",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 20 14 * * *"
+      "schedule": "0 20 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardTablesTests/function.json
+++ b/CovidStateDashboardTablesTests/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesTests",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 30 14 * * *"
+      "schedule": "0 30 14 * * Tue,Fri"
     }
   ]
 }

--- a/CovidStateDashboardVaccines/function.json
+++ b/CovidStateDashboardVaccines/function.json
@@ -4,7 +4,7 @@
         "name": "CovidStateDashboardVaccines",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 5 14 * * *"
+        "schedule": "0 5 14 * * Tue,Fri"
       }
     ]
   }

--- a/CovidVaccineEquity/function.json
+++ b/CovidVaccineEquity/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineEquity",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 50 14 * * Wed"
+      "schedule": "0 50 14 * * Fri"
     }
   ]
 }

--- a/CovidVaccineHPIV2/function.json
+++ b/CovidVaccineHPIV2/function.json
@@ -4,7 +4,7 @@
       "name": "CovidVaccineHPIV2",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 5 15 * * Wed"
+      "schedule": "0 5 15 * * Fri"
     }
   ]
 }

--- a/CovidVariantsData/function.json
+++ b/CovidVariantsData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 55 14 * * Thu"
+        "schedule": "0 55 14 * * Fri"
       }
     ]
   }


### PR DESCRIPTION
We are moving to a new schedule in which most daily rollouts happen only on Tuesday and Friday mornings, and most weekly rollouts happen on Friday.  This adjusts most of the pipeline for this new schedule.  Equity is still processing Tuesday, as it is still up in the air.  Some of the weekly jobs moved to Friday may get moved to Tuesday, but most of this is confirmed.