### PR TITLE
Shifted average window for cases and deaths by one day.

### DIFF
--- a/CovidStateDashboardTablesCasesDeaths/worker.js
+++ b/CovidStateDashboardTablesCasesDeaths/worker.js
@@ -97,7 +97,8 @@ const doCovidStateDashboardTablesCasesDeaths = async () => {
                     if (caseList[i].DATE.toISOString().split("T")[0] == pending_dateC) {
                         parse_state = 1;
                     }
-                } else {
+                }
+                if (parse_state == 1) {
                     sumCasesCount += caseList[i].VALUE;
                     summed_days += 1;
                 }
@@ -121,7 +122,8 @@ const doCovidStateDashboardTablesCasesDeaths = async () => {
                     if (deathsList[i].DATE.toISOString().split("T")[0] == pending_dateD) {
                         parse_state = 1;
                     }
-                } else {
+                } 
+                if (parse_state == 1) {
                     sumDeathsCount += deathsList[i].VALUE;
                     summed_days += 1;
                 }


### PR DESCRIPTION
Based on a communication from Lauren Nelson, this modifies the logic for computing cases and deaths daily average to re-interpret the meaning of "pending date" such that the averaged period is moved closer to the present by one day.

<img width="475" alt="CleanShot 2022-05-16 at 17 18 08" src="https://user-images.githubusercontent.com/287977/168702620-e4e7b85a-f10d-4573-9d33-7cc1d3247a98.png">
