### PR TITLE
add additional trigger to CovidAutoBuilder

### DIFF
--- a/CovidAutoBuilder/function.json
+++ b/CovidAutoBuilder/function.json
@@ -4,7 +4,7 @@
         "name": "CovidAutoBuilder",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 25 16 * * Tue,Fri"
+        "schedule": "0 25,55 16 * * Tue,Fri"
       }
     ]
   }


### PR DESCRIPTION
This PR is meant to address a situation where the 9:25 auto build wins a race against, for example, the equity PR merge (which results in another build being required).