### PR TITLE
added 100 days to max case/death data length

### DIFF
--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-cases.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-cases.json
@@ -165,7 +165,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -210,7 +210,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -254,7 +254,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -298,7 +298,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-deaths.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-deaths.json
@@ -165,7 +165,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -210,7 +210,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -255,7 +255,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -299,7 +299,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1000,
                   "items": {
                     "required": true,
                     "type": "object",


### PR DESCRIPTION
Today marks 901 days since 2020-03-01, which is the date our data starts at. I'm imagining there is no technical issue with the charts displaying 900+ cases, so this fix buys us 100 more days.

I'll set a slack reminder to check on this issue in ~90 days from now...