### PR TITLE
Extend tests len

### DIFF
--- a/CovidStateDashboardTablesTests/worker.js
+++ b/CovidStateDashboardTablesTests/worker.js
@@ -198,7 +198,7 @@ const doCovidStateDashboardTablesTests = async (slack) => {
                     workForValidation.push(newWork)
                 }
             }
-            splitArrayIntoChunks(workForValidation, 40).forEach(a => {
+            splitArrayIntoChunks(workForValidation, 20).forEach(a => {
                 promises.push(validateJSON_Remote("failed validation", outputSchema.json, a));
             })
         }

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-cases.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-cases.json
@@ -165,7 +165,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -210,7 +210,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -254,7 +254,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -298,7 +298,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-deaths.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/confirmed-deaths.json
@@ -165,7 +165,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -210,7 +210,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -255,7 +255,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -299,7 +299,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 1000,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/positivity-rate.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/positivity-rate.json
@@ -153,7 +153,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -198,7 +198,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -243,7 +243,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/total-tests.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesCasesDeathsTests/schema/output/total-tests.json
@@ -157,7 +157,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -201,7 +201,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -245,7 +245,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -290,7 +290,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesTests/schema/output/positivity-rate.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesTests/schema/output/positivity-rate.json
@@ -153,7 +153,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -198,7 +198,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -243,7 +243,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",

--- a/common/SQL/CDT_COVID/CovidStateDashboardTablesTests/schema/output/total-tests.json
+++ b/common/SQL/CDT_COVID/CovidStateDashboardTablesTests/schema/output/total-tests.json
@@ -157,7 +157,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -201,7 +201,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -245,7 +245,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",
@@ -290,7 +290,7 @@
                   "type": "array",
                   "uniqueItems": true,
                   "minItems": 300,
-                  "maxItems": 900,
+                  "maxItems": 1200,
                   "items": {
                     "required": true,
                     "type": "object",


### PR DESCRIPTION
- Extended a number of allowed data lengths to 1200, per slack suggestion
- Remote validation was failing for tests data so I made the request sizes smaller

This code was used to rerun 2 failed jobs from this morning.