### PR TITLE
moved jobs to run on thursday

### DIFF
--- a/CovidAutoBuilder/function.json
+++ b/CovidAutoBuilder/function.json
@@ -4,7 +4,7 @@
         "name": "CovidAutoBuilder",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 25,55 16 * * Tue,Fri"
+        "schedule": "0 25,55 16 * * Thu"
       }
     ]
   }

--- a/CovidEquityData/function.json
+++ b/CovidEquityData/function.json
@@ -4,7 +4,7 @@
       "name": "CovidEquityData",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 20 20 * * Wed"
+      "schedule": "0 20 14 * * Wed"
     }
   ]
 }

--- a/CovidEquityData/index.js
+++ b/CovidEquityData/index.js
@@ -10,7 +10,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} started (planned Wednesday 1:20pm)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:20am)`)).json()).ts;
 
     const Pr = await doCovidEquityData();
 

--- a/CovidEquityImpact/function.json
+++ b/CovidEquityImpact/function.json
@@ -4,7 +4,7 @@
         "name": "CovidEquityImpact",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 05 15 * * Fri"
+        "schedule": "0 05 15 * * Thu"
       }
     ]
   }

--- a/CovidEquityImpact/index.js
+++ b/CovidEquityImpact/index.js
@@ -7,7 +7,7 @@ module.exports = async function (context, myTimer) {
 
     let slackPostTS = null;
     try {
-        slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 8:05am)`)).json()).ts;
+        slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 8:05am)`)).json()).ts;
 
         const TreeRunResults = await doCovidEquityImpact(false);
 

--- a/CovidEquityImpactPreview/function.json
+++ b/CovidEquityImpactPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidEquityImpactPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 30 20,21,22 * * Wed"
+        "schedule": "0 30 14 * * Wed"
       }
     ]
   }

--- a/CovidEquityImpactPreview/index.js
+++ b/CovidEquityImpactPreview/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
 
   let slackPostTS = null;
   try {
-      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 1:30pm)`)).json()).ts;
+      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:30am)`)).json()).ts;
 
       const TreeRunResults = await doCovidEquityImpact(true); // preview run
 

--- a/CovidPostvaxDataNoboost/function.json
+++ b/CovidPostvaxDataNoboost/function.json
@@ -4,7 +4,7 @@
         "name": "CovidPostvaxDataNoboost",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 45 14 * * Fri"
+        "schedule": "0 45 14 * * Thu"
       }
     ]
   }

--- a/CovidPostvaxDataNoboost/index.js
+++ b/CovidPostvaxDataNoboost/index.js
@@ -9,7 +9,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 7:35am -- should snooze unless first week of month)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:45am -- should snooze unless first week of month)`)).json()).ts;
     if (isIdleDay({weekends_off:true, holidays_off:true, first_week_only:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed`);
       await slackBotReactionAdd(debugChannel, slackPostTS, 'zzz');

--- a/CovidPostvaxDataPreviewNoboost/function.json
+++ b/CovidPostvaxDataPreviewNoboost/function.json
@@ -4,7 +4,7 @@
         "name": "CovidPostvaxDataNoboostPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 30 15 * * Thu"
+        "schedule": "0 30 15 * * Wed"
       }
     ]
   }

--- a/CovidPostvaxDataPreviewNoboost/index.js
+++ b/CovidPostvaxDataPreviewNoboost/index.js
@@ -9,7 +9,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 8am -- should snooze unless first week of month )`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 8:30am -- should snooze unless first week of month )`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true, first_week_only:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed`);

--- a/CovidStateDashboardSummary/function.json
+++ b/CovidStateDashboardSummary/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardSummary",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 45 14 * * Tue,Fri"
+      "schedule": "0 45 14 * * Thu"
     }
   ]
 }

--- a/CovidStateDashboardSummary/index.js
+++ b/CovidStateDashboardSummary/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:45am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:45am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardTablesCasesDeaths/function.json
+++ b/CovidStateDashboardTablesCasesDeaths/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesCasesDeaths",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 10 14 * * Tue,Fri"
+      "schedule": "0 10 14 * * Thu"
     }
   ]
 }

--- a/CovidStateDashboardTablesCasesDeaths/index.js
+++ b/CovidStateDashboardTablesCasesDeaths/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:10am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:10am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardTablesHospitals/function.json
+++ b/CovidStateDashboardTablesHospitals/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesHospitals",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 20 14 * * Tue,Fri"
+      "schedule": "0 20 14 * * Thu"
     }
   ]
 }

--- a/CovidStateDashboardTablesHospitals/index.js
+++ b/CovidStateDashboardTablesHospitals/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:20am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:20am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardTablesTests/function.json
+++ b/CovidStateDashboardTablesTests/function.json
@@ -4,7 +4,7 @@
       "name": "CovidStateDashboardTablesTests",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 30 14 * * Tue,Fri"
+      "schedule": "0 30 14 * * Thu"
     }
   ]
 }

--- a/CovidStateDashboardTablesTests/index.js
+++ b/CovidStateDashboardTablesTests/index.js
@@ -29,7 +29,7 @@ module.exports = async function (context) {
   const slack = new SlackConnector(slackBotGetToken(), debugChannel, {username:slackBotName});
 
   try {
-    await slack.Chat(`${appName} (Every Tue,Fri @ 7:30am)`);
+    await slack.Chat(`${appName} (Every Thursday @ 7:30am)`);
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slack.Reply(`${appName} snoozed (weekend or holiday)`);

--- a/CovidStateDashboardVaccines/function.json
+++ b/CovidStateDashboardVaccines/function.json
@@ -4,7 +4,7 @@
         "name": "CovidStateDashboardVaccines",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 5 14 * * Fri"
+        "schedule": "0 5 14 * * Thu"
       }
     ]
   }

--- a/CovidStateDashboardVaccines/index.js
+++ b/CovidStateDashboardVaccines/index.js
@@ -10,7 +10,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tue,Fri @ 7:05am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:05am)`)).json()).ts;
 
     if (isIdleDay({weekends_off:true, holidays_off:true})) {
       await slackBotReplyPost(debugChannel, slackPostTS,`${appName} snoozed (weekend or holiday)`);

--- a/CovidVariantsData/function.json
+++ b/CovidVariantsData/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsData",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 55 14 * * Fri"
+        "schedule": "0 55 14 * * Thu"
       }
     ]
   }

--- a/CovidVariantsData/index.js
+++ b/CovidVariantsData/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Friday @ 7:55am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Thursday @ 7:55am)`)).json()).ts;
 
     const TreeRunResults = await doCovidVariantsData(false);
 

--- a/CovidVariantsDataPreview/function.json
+++ b/CovidVariantsDataPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsDataPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 50 19-23 * * Wed"
+        "schedule": "0 50 21-23 * * Wed"
       }
     ]
   }

--- a/CovidVariantsDataPreview/index.js
+++ b/CovidVariantsDataPreview/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 1pm,2pm,3pm)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 2:50pm,3:50pm,4:50pm)`)).json()).ts;
 
     const TreeRunResults = await doCovidVariantsData(true);
 


### PR DESCRIPTION
Excuse the typo in the branch name...

Changes:
- Moved Tuesday/Friday jobs to Thursday only
- Updated slack messages with new timings
- Moved equity data pipeline sooner in the day so that the approver has a full day to look at it. I verified that all the tables used by this pipeline are updated on Tuesday morning/afternoon, so a Wednesday update should be perfectly fine. The equity impact preview pipeline was similarly modified to run on Wed morning.
- Got rid of 2 Variants Preview pipeline runs since the data hasn't been arriving as early as those pipelines were running