### PR TITLE
more pipeline scheduling tweaks

### DIFF
--- a/CovidEquityData/index.js
+++ b/CovidEquityData/index.js
@@ -10,7 +10,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:20am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 11:00am)`)).json()).ts;
 
     const Pr = await doCovidEquityData();
 

--- a/CovidEquityImpactPreview/function.json
+++ b/CovidEquityImpactPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidEquityImpactPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 30 14 * * Wed"
+        "schedule": "0 10 18 * * Wed"
       }
     ]
   }

--- a/CovidEquityImpactPreview/index.js
+++ b/CovidEquityImpactPreview/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
 
   let slackPostTS = null;
   try {
-      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 7:30am)`)).json()).ts;
+      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 11:10am)`)).json()).ts;
 
       const TreeRunResults = await doCovidEquityImpact(true); // preview run
 

--- a/CovidVariantsDataPreview/function.json
+++ b/CovidVariantsDataPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidVariantsDataPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 50 21-23 * * Wed"
+        "schedule": "0 50 21-23 * * Tue"
       }
     ]
   }

--- a/CovidVariantsDataPreview/index.js
+++ b/CovidVariantsDataPreview/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 2:50pm,3:50pm,4:50pm)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Tuesday @ 2:50pm,3:50pm,4:50pm)`)).json()).ts;
 
     const TreeRunResults = await doCovidVariantsData(true);
 


### PR DESCRIPTION
- Moved the equity pipelines that write to the "to-review" location to Wednesday after 11 am based on slack feedback from Lauren Nelson
- Moved the variant preview pipeline to Tuesday afternoon based on feedback from Mayuri Panditrao

I am fairly confident there will be more changes to pipeline timing within the next week but this is what we know currently.