### PR TITLE
moved equity data pipelines to monday

### DIFF
--- a/CovidEquityData/function.json
+++ b/CovidEquityData/function.json
@@ -4,7 +4,7 @@
       "name": "CovidEquityData",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 18 * * Wed"
+      "schedule": "0 0 15 * * Mon"
     }
   ]
 }

--- a/CovidEquityData/index.js
+++ b/CovidEquityData/index.js
@@ -10,7 +10,7 @@ module.exports = async function (context, myTimer) {
   const appName = context.executionContext.functionName;
   let slackPostTS = null;
   try {
-    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 11:00am)`)).json()).ts;
+    slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Monday @ 8:00am)`)).json()).ts;
 
     const Pr = await doCovidEquityData();
 

--- a/CovidEquityImpactPreview/function.json
+++ b/CovidEquityImpactPreview/function.json
@@ -4,7 +4,7 @@
         "name": "CovidEquityImpactPreview",
         "type": "timerTrigger",
         "direction": "in",
-        "schedule": "0 10 18 * * Wed"
+        "schedule": "0 10 15 * * Mon"
       }
     ]
   }

--- a/CovidEquityImpactPreview/index.js
+++ b/CovidEquityImpactPreview/index.js
@@ -8,7 +8,7 @@ module.exports = async function (context, myTimer) {
 
   let slackPostTS = null;
   try {
-      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Wednesday @ 11:10am)`)).json()).ts;
+      slackPostTS = (await (await slackBotChatPost(debugChannel,`${appName} (Every Monday @ 8:10am)`)).json()).ts;
 
       const TreeRunResults = await doCovidEquityImpact(true); // preview run
 


### PR DESCRIPTION
@jbum FYI a new health equity schedule was approved so that there is a larger window of time for the data to be approved:
1. Data team generates new tables at some point on **Thursday**
2. We generate PR and staged data on the following **Monday**
3. Health equity team has until **Wednesday** evening to approve the staged data
4. Staged data is merged on Thursday 

To accommodate this shift in schedule, no updates to health equity data will happen this week. Additionally, the data will be 1 week older than it would have been otherwise.